### PR TITLE
Feature #13: Winston library, change the log format so as to display t…

### DIFF
--- a/src/config/logger-config.js
+++ b/src/config/logger-config.js
@@ -1,8 +1,14 @@
 const { createLogger, format, transports } = require('winston');
 const { combine, timestamp, label, printf } = format;
 
-const customFormat = printf(( { level, message, timestamp, error } ) => {
-    return `${timestamp} : ${level}: ${message}`;
+const modifySplatData = function(info){
+    const splatInfo = info[Symbol.for('splat')];
+    return (!splatInfo || splatInfo.length == 0) ? '' : JSON.stringify(splatInfo);
+}
+
+const customFormat = printf(info => {
+    const metaDataStr = modifySplatData(info);
+    return `${info.timestamp} : ${info.level}: ${info.message} ${metaDataStr}`;
 });
 
 const logger = createLogger({


### PR DESCRIPTION
#13 

While logging, now we can log the additional parameters along with the message and severity level.
For example, 

`app.listen(ServerConfig.PORT, () => {
    console.log('Successfully started the server on PORT : ${ServerConfig.PORT}');
    Logger.error('Checking error logging', {msg: 'Something went wrong'})
});`

Now, along with the message, it will also be able to log the additional parameters (or the meta data)
So, instead of log output:
<img width="568" alt="Screenshot 2023-06-05 210804" src="https://github.com/singhsanket143/Flights-Service/assets/17049788/c95858ca-bda0-46ce-84e5-82f123f05ce4">
We will be able to log the meta data as follows:
<img width="557" alt="Untitled232" src="https://github.com/singhsanket143/Flights-Service/assets/17049788/fc5aad89-bf0e-443a-8a3d-69b60b5ce693">

We can pass any number of additional meta data, it will be able to log it in a stringify fashion